### PR TITLE
initial test: flag_outlier_chs

### DIFF
--- a/tests/test_simulated.py
+++ b/tests/test_simulated.py
@@ -1,0 +1,46 @@
+import pytest
+
+from pathlib import Path
+
+from mne.datasets import sample
+import mne_bids
+
+import pylossless as ll
+from utils import _simulate_raw
+
+data_path = sample.data_path()
+meg_path = data_path / 'MEG' / 'sample'
+raw_fname = meg_path / 'sample_audvis_raw.fif'
+fwd_fname = meg_path / 'sample_audvis-meg-eeg-oct-6-fwd.fif'
+
+
+@pytest.mark.parametrize('raw_fname, fwd_fname',
+                         [(raw_fname, fwd_fname)])
+def test_flag_outlier_chs(raw_fname, fwd_fname):
+    # make BIDS object
+    bpath = mne_bids.get_bids_path_from_fname(raw_fname, check=False)
+    bpath.suffix = 'sample_audvis_raw'
+
+    # Load real data as the template
+    raw = mne_bids.read_raw_bids(bpath)
+    raw.set_eeg_reference(projection=True)
+
+    raw_sim = _simulate_raw(raw, fwd_fname)
+
+    # Generate Pipeline Config
+    config = ll.config.Config()
+    config.load_default()
+    config.save("sample_audvis_config.yaml")
+
+    # Run first step of Pipeline
+    pipeline = ll.LosslessPipeline('sample_audvis_config.yaml')
+    pipeline.raw = raw_sim
+    pipeline.flag_outlier_chs()
+    # Test
+    for noisy_ch in ['EEG 001', 'EEG 005', 'EEG 009']:
+        assert noisy_ch in pipeline.flagged_chs['manual']
+
+    # Delete temp config file
+    tmp_config_fname = Path(pipeline.config_fname).absolute()
+    tmp_config_fname.unlink()  # delete config file
+    print('DONE!!')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,48 @@
+import numpy as np
+import mne
+from mne import make_ad_hoc_cov
+from mne.simulation import (simulate_sparse_stc, simulate_raw, add_noise)
+
+n_dipoles = 4  # number of dipoles to create
+epoch_duration = 2.  # duration of each epoch/event
+rng = np.random.RandomState(0)  # random state (make reproducible)
+
+
+def data_fun(times):
+    """Generate time-staggered sinusoids at harmonics of 10Hz"""
+    n_samp = len(times)
+    window = np.zeros(n_samp)
+    n = 0  # harmonic number
+    start, stop = [int(ii * float(n_samp) / (2 * n_dipoles))
+                   for ii in (2 * n, 2 * n + 1)]
+    window[start:stop] = 1.
+    n += 1
+    data = 25e-9 * np.sin(2. * np.pi * 10. * n * times)
+    data *= window
+    return data
+
+
+def _simulate_raw(raw, fwd_fname,
+                  n_dipoles=n_dipoles,
+                  epoch_duration=epoch_duration,
+                  rng=rng):
+    """Simulate a mne raw object with added noise"""
+    times = raw.times[:int(raw.info['sfreq'] * epoch_duration)]
+    fwd = mne.read_forward_solution(fwd_fname)
+    src = fwd['src']
+    stc = simulate_sparse_stc(src, n_dipoles=n_dipoles, times=times,
+                              data_fun=data_fun, random_state=rng)
+
+    # Simulate Raw Data
+    raw_sim = simulate_raw(raw.info, [stc] * 10, forward=fwd, verbose=True)
+    raw_sim.pick_types(eeg=True)
+    cov = make_ad_hoc_cov(raw_sim.info)
+    add_noise(raw_sim, cov, iir_filter=[0.2, -0.2, 0.04], random_state=rng)
+
+    make_these_noisy = ['EEG 001', 'EEG 005', 'EEG 009']
+    cov_noisy = make_ad_hoc_cov(raw_sim.copy().pick(make_these_noisy).info,
+                                std=dict(eeg=.000002))
+    add_noise(raw_sim, cov_noisy,
+              iir_filter=[0.2, -0.2, 0.04],
+              random_state=rng)
+    return raw_sim


### PR DESCRIPTION
Here is a first test.

I am generating a simulated raw object, and adding noise to 3 channels: `'EEG 001'` , `'EEG 005'`, and `'EEG 009'`.

![b389e379-2b0f-4e6a-8064-c41759c0e082](https://user-images.githubusercontent.com/52462026/223855781-f0037b59-ed61-439e-a884-45793b79b806.png)

then I run `pylossless.pipeline.flag_outlier_chs`, and test that the method indeed flags those 3 channels. It does.


I think this modules `tests/test_simulated`, is a great way to test that each of our pipeline methods behaves as expected _in a controlled environment,_ . After this, I will generate a test module using _real data_ (even more important). 