### PR TITLE
FIX: skip deploying to heroku step in the CI workflow, for now.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,43 @@
+version: 2.1
+orbs:
+  python: circleci/python@2.0.3
+  heroku: circleci/heroku@1.2.6
+
+jobs:
+  build_and_test: # this can be any name you choose
+    executor: python/default
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: pip
+      - run:
+          name: Install pytest dependency  # TODO: replace this by handling dependencies in setup.py
+          command: |
+            pip install pytest
+      - run:
+          name: Run tests
+          command: |
+            python -m pytest tests/test_simulated.py
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - .
+
+  # deploy: # this can be any name you choose
+  #  executor: python/default
+  #  steps:
+  #    - attach_workspace:
+  #        at: ~/project
+  #    - heroku/deploy-via-git:
+  #        force: true # force push when pushing to the heroku remote, see: https://devcenter.heroku.com/articles/git
+
+workflows:
+  test_my_app:
+    jobs:
+      - build_and_test
+      #- deploy:
+      #    requires:
+      #      - build_and_test # only deploy if the build_and_test job has completed
+      #    filters:
+      #      branches:
+      #        only: main # only deploy when on main


### PR DESCRIPTION
It won't work until we have a Heroku account and app for lina-usc / pylossless. 

Anyways the important part right now is that the tests are passing, and we don't need to deploy to Heroku to confirm that.