### PR TITLE
Move slider sharing duties to `qcgui`

### DIFF
--- a/pylossless/dash/css_defaults.py
+++ b/pylossless/dash/css_defaults.py
@@ -84,11 +84,15 @@ CSS['timeseries-container'] = "w-100"  # border border-success
 # TOPO PLOTS
 ############################################################
 
+# bootstrap format for topo slider div
+CSS['topo-slider-div'] = "d-inline-block align-middle"
+
 # bootstrap for topo dcc-graph
 CSS['topo-dcc'] = "bg-secondary bg-opacity-50 border rounded"  # border-info
 
 # bootstrap for div containing topo-dcc
-CSS['topo-dcc-div'] = 'bg-secondary bg-opacity-50 align-top'  # border border-warning
+CSS['topo-dcc-div'] = 'bg-secondary bg-opacity-50 d-inline-block align-top'  # border border-warning
+STYLE['topo-dcc-div'] = {'width': '90%'}  # so that slider can fit to the left
 
 # boostrap for final container: self.container_plot
 CSS['topo-container'] = 'topo-div shadow-lg'  # border border-success

--- a/pylossless/dash/topo_viz.py
+++ b/pylossless/dash/topo_viz.py
@@ -18,7 +18,7 @@ from mne.utils.check import _check_sphere
 from mne.viz.topomap import _setup_interp, _check_extrapolate
 
 from . import ic_label_cmap
-from .css_defaults import CSS
+from .css_defaults import CSS, STYLE
 
 from copy import copy
 
@@ -44,10 +44,9 @@ class TopoData:
 
 class TopoViz:
     def __init__(self, app, montage=None, data=None,  # : TopoData,
-                 rows=5, cols=4, margin_x=4/5, width=450, height=700,
-                 margin_y=2/5, topo_slider_id=None,
-                 head_contours_color="black", cmap='RdBu_r',
-                 show_sensors=True, refresh_input=None):
+                 rows=5, cols=4, margin_x=4/5, width=400, height=600,
+                 margin_y=2/5, head_contours_color="black", cmap='RdBu_r',
+                 show_sensors=True, show_slider=True, refresh_input=None):
         """ """
         self.refresh_input = refresh_input
         self.montage = montage
@@ -62,20 +61,21 @@ class TopoViz:
         self.cmap = cmap
         self.titles = None
         self.show_sensors = show_sensors
+        self.show_slider = show_slider
         fig = make_subplots(rows=rows, cols=cols,
                             horizontal_spacing=0.01,
                             vertical_spacing=0.01)
         self.graph = dcc.Graph(figure=fig, id='topo-graph',
-                               className=CSS['topo-dcc'])  # 'dcc-graph')
+                               className=CSS['topo-dcc'])
         self.graph_div = html.Div(children=[self.graph],
                                   id='topo-graph-div',
-                                  className=CSS['topo-dcc-div'])
+                                  className=CSS['topo-dcc-div'],
+                                  style=STYLE['topo-dcc-div'])
 
         self.margin_x = margin_x
         self.margin_y = margin_y
         self.offset = 0
         self.topo_slider = None
-        self.use_topo_slider = topo_slider_id
         self.head_contours_color = head_contours_color
         self.info = None
         self.pos = None
@@ -201,7 +201,7 @@ class TopoViz:
             height=self.height,
             plot_bgcolor='rgba(0,0,0,0)',  #'#EAEAF2', #'rgba(44,44,44,.5)',
             paper_bgcolor='rgba(0,0,0,0)')  #'#EAEAF2')  #'rgba(44,44,44,.5)')
-        self.graph.figure['layout'].update(margin=dict(l=0, r=0, b=0, t=0))
+        self.graph.figure['layout'].update(margin=dict(l=0, r=0, b=0, t=20))
 
     @property
     def nb_topo(self):
@@ -219,25 +219,22 @@ class TopoViz:
                                       included=False,
                                       updatemode='mouseup',
                                       vertical=True,
-                                      verticalHeight=self.graph.figure.layout.height)
-        self.topo_slider_div = html.Div(dcc.Slider)
+                                      verticalHeight=400)
+        self.topo_slider_div = html.Div(self.topo_slider,
+                                        className=CSS['topo-slider-div'],
+                                        style={})
+        if not self.show_slider:
+            self.topo_slider_div.style.update({'display': 'none'})
 
     def set_div(self):
-        if self.use_topo_slider is None:
-            # outer_div includes slider obj
-            graph_components = [self.topo_slider_div, self.graph_div]
-        else:
-            # outer_div is just the graph
-            graph_components = [self.graph_div]
+        # outer_div includes slider obj
+        graph_components = [self.topo_slider_div, self.graph_div]
         self.container_plot = html.Div(children=graph_components,
                                        className=CSS['topo-container'])
 
     def set_callback(self):
         args = [Output('topo-graph', 'figure')]
-        if self.use_topo_slider:
-            args += [Input(self.use_topo_slider, 'value')]
-        else:
-            args += [Input('topo-slider', 'value')]
+        args += [Input('topo-slider', 'value')]
         if self.refresh_input:
             args += [self.refresh_input]
 
@@ -265,7 +262,6 @@ class TopoVizICA(TopoViz):
         data = TopoData([dict(zip(montage.ch_names, component))
                          for component in ica.get_components().T])
         data.topo_values.index = list(ic_labels.keys())
-        print('%%%%%', data)
         return data
 
     def load_recording(self, montage, ica, ic_labels):


### PR DESCRIPTION
Fixes #61 

1. This removes some of the complexity out of `mne_visualizer`, as it is simpler to handle slider sharing directly in our qcr app.

2. I think this improves the API of MNEVisualizer. no more `time_slider` `ch_slider` args that require a dash id. There are new, clear, args named `show_ch_slider` / `show_time_slider`, for show showing/hiding sliders.

3. Now, you can control the topoplot view directly with its own slider. The ICA time-series and ICA-Topo plot sliders are linked. Want to hide it? NP, just pass `show_slider=False` to the `TopoVizICA` constructor.

![Screen Shot 2023-03-15 at 9 44 25 AM](https://user-images.githubusercontent.com/52462026/225350076-a87306aa-4544-4c6a-9b87-05fab42ef19b.png)
