### PR TITLE
ENH: setup py to handle base / extras and link to requirements.txt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run:
           name: Install testing dependencies
           command: |
-            pip install pylossless[test]
+            pip install -r requirements_testing.txt
       - run:
           name: Check for flakes
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run:
           name: Install testing dependencies
           command: |
-            pip install -r requirements_testing.txt
+            pip install pylossless[test]
       - run:
           name: Check for flakes
           command: |

--- a/docs/requirements_doc.txt
+++ b/docs/requirements_doc.txt
@@ -1,4 +1,3 @@
-# docs
 sphinx!=4.1.0,<6
 pydata-sphinx-theme
 sphinx-design

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,13 +8,3 @@ scipy>=1.2.1
 mne_icalabel
 pyyaml
 scikit-learn
-
-# Dash
-gunicorn>=19.8.1
-dash>=1.0.0, <2.9.0
-dash-extensions>=0.1.7
-colorlover>=0.2.1
-dash_bootstrap_components
-
-# Tutorial requirement
-openneuro-py

--- a/requirements_qc.txt
+++ b/requirements_qc.txt
@@ -1,0 +1,5 @@
+gunicorn>=19.8.1
+dash>=1.0.0, <2.9.0
+dash-extensions>=0.1.7
+colorlover>=0.2.1
+dash_bootstrap_components

--- a/setup.py
+++ b/setup.py
@@ -6,22 +6,35 @@ Tyler Collins <collins.tyler.k@gmail.com>
 License: MIT
 """
 
-from setuptools import setup
+from pathlib import Path
+from setuptools import setup, find_packages
 
-install_requires = ['numpy', 'EDFlib-Python', 'mne', 'mne_bids', 'pandas',
-                    'xarray', 'scipy', 'mne_icalabel', 'pyyaml',
-                    'scikit-learn']
-        
+with Path('requirements.txt').open() as f:
+    requirements = f.read().splitlines()
+
+extras = {
+    'dash': 'requirements_qc.txt',
+    'test': 'requirements_testing.txt',
+    'doc': './docs/requirements_doc.txt'
+}
+
+extras_require = {}
+for extra, req_file in extras.items():
+    with Path(req_file).open() as file:
+        requirements_extra = file.read().splitlines()
+    extras_require[extra] = requirements_extra
+
+qc_entry_point = ["pylossless_qc=pylossless.dash.app:main"]
 setup(
     name='pylossless',
-    version="0.0.1",
+    version='0.0.1',
     description='Python port of EEG-IP-L pipeline for preprocessing EEG.',
-    python_requires='>=3.5',
     author="Scott Huberty",
     author_email='seh33@uw.edu',
-    url='https://github.com/scott-huberty/pylossless',
-    packages=['pylossless'],
-    install_requires=install_requires,
+    url='https://github.com/lina-usc/pylossless',
+    packages=find_packages(),
+    install_requires=requirements,
+    extras_require=extras_require,
     include_package_data=True,
-    entry_points={"console_scripts": ["pylossless_qc=pylossless.dash.app:main"]}
+    entry_points={"console_scripts": qc_entry_point}
 )


### PR DESCRIPTION
Closes #34 
`pip install pylossless[dash]` now possible for dashboard dependencies.

`setup.py` now uses requirements.txt for hard dependencies which only contains our agreed upon dependencies for the automated pipeline.