### PR TITLE
FIX: find breaks logging

### DIFF
--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -1052,7 +1052,7 @@ class LosslessPipeline():
         self.run_staging_script()
 
         # find breaks
-        self.find_breaks("Looking for break periods between tasks")
+        self.find_breaks(message="Looking for break periods between tasks")
 
         # OPTIONAL: Flag chs/epochs based off fixed std threshold of time axis
         self.flag_epochs_fixed_threshold()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -5,6 +5,7 @@ import pytest
 
 import pylossless as ll
 
+import mne
 import mne_bids
 
 import openneuro
@@ -65,3 +66,20 @@ def test_pipeline_run(dataset):
     pipeline.run_with_raw(pipeline.raw)
     Path('test_config.yaml').unlink()  # delete config file
     shutil.rmtree(bids_root)
+
+
+@pytest.mark.test_find_breaks
+def test_find_breaks():
+    """Make sure MNE's annotate_break function can run."""
+    testing_path = mne.datasets.testing.data_path()
+    fname = testing_path / 'EDF' / 'test_edf_overlapping_annotations.edf'
+    raw = mne.io.read_raw_edf(fname, preload=True)
+    config = ll.config.Config()
+    config.load_default()
+    config['find_breaks'] = {}
+    config['find_breaks']['min_break_duration'] = 15
+    config.save("find_breaks_config.yaml")
+    pipeline = ll.LosslessPipeline('find_break_config.yaml')
+    pipeline.raw = raw
+    pipeline.find_breaks()
+    Path('find_breaks_config.yaml').unlink()  # delete config file

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -47,16 +47,26 @@ def load_openneuro_bids():
         print(list(bids_path.fpath.glob('*')))
         sleep(1)
     raw = mne_bids.read_raw_bids(bids_path)
+    annots = mne.Annotations(onset=[1, 15],
+                             duration=[1, 1],
+                             description=['test_annot', 'test_annot'])
+    raw.set_annotations(annots)
     return raw, config, bids_root
 
 
 # @pytest.mark.xfail
-@pytest.mark.parametrize('dataset', ['openneuro'])
-def test_pipeline_run(dataset):
+@pytest.mark.parametrize('dataset, find_breaks', [('openneuro', True),
+                                                  ('openneuro', False)])
+def test_pipeline_run(dataset, find_breaks):
     """test running the pipeline."""
     if dataset == 'openneuro':
         raw, config, bids_root = load_openneuro_bids()
 
+    if find_breaks:
+        config['find_breaks'] = {}
+        config['find_breaks']['min_break_duration'] = 9
+        config['find_breaks']['t_start_after_previous'] = 1
+        config['find_breaks']['t_stop_before_next'] = 0
     config.save("test_config.yaml")
     pipeline = ll.LosslessPipeline('test_config.yaml')
     not_in_1020 = ['EXG1', 'EXG2', 'EXG3', 'EXG4',
@@ -64,6 +74,10 @@ def test_pipeline_run(dataset):
     pipeline.raw = raw.pick('eeg',
                             exclude=not_in_1020).load_data()
     pipeline.run_with_raw(pipeline.raw)
+
+    if find_breaks:
+        assert 'BAD_break' in raw.annotations.description
+
     Path('test_config.yaml').unlink()  # delete config file
     shutil.rmtree(bids_root)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -68,8 +68,8 @@ def test_pipeline_run(dataset):
     shutil.rmtree(bids_root)
 
 
-@pytest.mark.test_find_breaks
-def test_find_breaks():
+@pytest.mark.parametrize('logging', [True, False])
+def test_find_breaks(logging):
     """Make sure MNE's annotate_break function can run."""
     testing_path = mne.datasets.testing.data_path()
     fname = testing_path / 'EDF' / 'test_edf_overlapping_annotations.edf'
@@ -81,5 +81,8 @@ def test_find_breaks():
     config.save("find_breaks_config.yaml")
     pipeline = ll.LosslessPipeline('find_break_config.yaml')
     pipeline.raw = raw
-    pipeline.find_breaks()
+    if logging:
+        pipeline.find_breaks(message="Looking for break periods between tasks")
+    else:
+        pipeline.find_breaks()
     Path('find_breaks_config.yaml').unlink()  # delete config file


### PR DESCRIPTION
the logging statement for find breaks is not positional, fixed to specify it as a keyword argument. 