### PR TITLE
FIX: Make sure annotations dont overlap with adjacent epochs

### DIFF
--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -7,6 +7,7 @@
 
 """Classes and Functions for running the Lossless Pipeline."""
 
+from copy import deepcopy
 from pathlib import Path
 from functools import partial
 
@@ -464,6 +465,24 @@ class LosslessPipeline():
         """Load the config file."""
         self.config = Config().read(self.config_fname)
 
+    def _check_sfreq(self):
+        """Make sure sampling frequency is an integer.
+
+        If the sfreq is a float, it will cause slightly incorrect mappings
+        from epochs to raw annotations. For example the annotation might start
+        at 0.98 when it should start at 1, which will result in 2 epochs
+        being dropped the next time data are epoched.
+        """
+        sfreq = self.raw.info['sfreq']
+        if not sfreq.is_integer():
+            # we can't use f-strings in the logging module
+            msg = ("The Raw sampling frequency is %.2f. a non-integer"
+                   " sampling frequency can cause incorrect mapping of epochs "
+                   "to annotations. downsampling to %d" % (sfreq, int(sfreq)))
+            logger.warn(msg)
+            self.raw.resample(int(sfreq))
+        return self.raw
+
     def set_montage(self):
         """Set the montage."""
         analysis_montage = self.config['project']['analysis_montage']
@@ -501,8 +520,12 @@ class LosslessPipeline():
         """
         # Concatenate epoched data back to continuous data
         t_onset = epochs.events[inds, 0] / epochs.info['sfreq']
+        # We exclude the last sample from the duration because
+        # if the annot lasts the whole duration of the epoch
+        # it's end will coincide with the first sample of the
+        # next epoch, causing it to erroneously be rejected.
         duration = (np.ones_like(t_onset) /
-                    epochs.info['sfreq'] * len(epochs.times)
+                    epochs.info['sfreq'] * len(epochs.times[:-1])
                     )
         description = [f'bad_pylossless_{event_type}'] * len(t_onset)
         annotations = mne.Annotations(t_onset, duration, description,
@@ -543,7 +566,12 @@ class LosslessPipeline():
         # TODO: automatically load detrend/preload description from MNE.
         logger.info("🧹 Epoching..")
         events = self.get_events()
-        epoching_kwargs = self.config['epoching']['epochs_args']
+        epoching_kwargs = deepcopy(self.config['epoching']['epochs_args'])
+
+        # MNE epoching is end-inclusive, causing an extra time
+        # sample be included. This removes that extra sample:
+        # https://github.com/mne-tools/mne-python/issues/6932
+        epoching_kwargs["tmax"] -= 1 / self.raw.info['sfreq']
         if detrend is not None:
             epoching_kwargs['detrend'] = detrend
         epochs = mne.Epochs(self.raw, events=events,
@@ -1046,6 +1074,10 @@ class LosslessPipeline():
 
     @lossless_time
     def _run(self):
+
+        # Make sure sampling frequency is an integer
+        self._check_sfreq()
+
         self.set_montage()
 
         # 1. Execute the staging script if specified.

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -504,6 +504,10 @@ class LosslessPipeline():
         duration = (np.ones_like(t_onset) /
                     epochs.info['sfreq'] * len(epochs.times)
                     )
+
+        t_onset += (2 / epochs.info['sfreq'])  # start 2 samples later
+        duration -= (4 / epochs.info['sfreq'])  # Shave 4 samples from end
+
         description = [f'bad_pylossless_{event_type}'] * len(t_onset)
         annotations = mne.Annotations(t_onset, duration, description,
                                       orig_time=self.raw.annotations.orig_time)

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -504,10 +504,6 @@ class LosslessPipeline():
         duration = (np.ones_like(t_onset) /
                     epochs.info['sfreq'] * len(epochs.times)
                     )
-
-        t_onset += (2 / epochs.info['sfreq'])  # start 2 samples later
-        duration -= (4 / epochs.info['sfreq'])  # Shave 4 samples from end
-
         description = [f'bad_pylossless_{event_type}'] * len(t_onset)
         annotations = mne.Annotations(t_onset, duration, description,
                                       orig_time=self.raw.annotations.orig_time)

--- a/pylossless/tests/test_simulated.py
+++ b/pylossless/tests/test_simulated.py
@@ -176,10 +176,16 @@ pipeline.raw = raw_sim
 @pytest.mark.parametrize('pipeline',
                          [(pipeline)])
 def test_simulated_raw(pipeline):
+    pipeline._check_sfreq()
+    # This file should have been downsampled
+    assert pipeline.raw.info['sfreq'] == 600
     # FIND NOISY EPOCHS
     pipeline.flag_ch_sd_epoch()
     # Epoch 2 was made noisy and should be flagged.
     assert np.array_equal(pipeline.flags['epoch']['ch_sd'], [2])
+    epochs = pipeline.get_epochs()
+    # only epoch at indice 2 should have been dropped
+    assert all(not tup or i == 2 for i, tup in enumerate(epochs.drop_log))
 
     # RUN FLAG_CH_SD
     pipeline.flag_ch_sd_ch()


### PR DESCRIPTION
Fixes #124 

- move `annotation` onset two samples later

- shave 4 samples from `annotation` end


- @christian-oreilly  can you please Review? I am not sure why starting the annotation 2-samples later and ending it 4-samples earlier was the magic number...

I remember something about how `mne` epochs include the end sample when they shouldn't but I want to make sure this issue was only in how the `onset` and `duration` in the `annotations` were defined and not also due to how we create `epochs`.
