### PR TITLE
Merge adjacent epoch flags into a single annotation

### DIFF
--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -346,72 +346,6 @@ def chan_neighbour_r(epochs, nneigbr, method):
     return m_neigbr_r.rename(ref_chan="ch")
 
 
-# TODO: check that annot type contains all unique flags
-def marks_flag_gap(
-    raw, min_gap_ms, included_annot_type=None, out_annot_name="bad_pylossless_gap"
-):
-    """Mark small gaps in time between pylossless annotations.
-
-    Parameters
-    ----------
-    raw : mne.Raw
-        An instance of mne.Raw
-    min_gap_ms : int
-        Time in milleseconds. If the time between two consecutive pylossless
-        annotations is less than this value, that time period will be
-        annotated.
-    included_annot_type : str (Default None)
-        Descriptions of the `mne.Annotations` in the `mne.Raw` to be included.
-        If `None`, includes ('bad_pylossless_ch_sd', 'bad_pylossless_low_r',
-        'bad_pylossless_ic_sd1', 'bad_pylossless_gap').
-    out_annot_name : str (default 'bad_pylossless_gap')
-        The description for the `mne.Annotation` That is created for any gaps.
-
-    Returns
-    -------
-    Annotations : `mne.Annotations`
-        An instance of `mne.Annotations`
-    """
-    if included_annot_type is None:
-        included_annot_type = (
-            "bad_pylossless_ch_sd",
-            "bad_pylossless_low_r",
-            "bad_pylossless_ic_sd1",
-            "bad_pylossless_gap",
-        )
-
-    if len(raw.annotations) == 0:
-        return mne.Annotations([], [], [], orig_time=raw.annotations.orig_time)
-
-    ret_val = np.array(
-        [
-            [annot["onset"], annot["duration"]]
-            for annot in raw.annotations
-            if annot["description"] in included_annot_type
-        ]
-    ).T
-
-    if len(ret_val) == 0:
-        return mne.Annotations([], [], [], orig_time=raw.annotations.orig_time)
-
-    onsets, durations = ret_val
-    offsets = onsets + durations
-    gaps = np.array(
-        [
-            min(onset - offsets[offsets < onset]) if np.sum(offsets < onset) else np.inf
-            for onset in onsets[1:]
-        ]
-    )
-    gap_mask = gaps < min_gap_ms / 1000
-
-    return mne.Annotations(
-        onset=onsets[1:][gap_mask] - gaps[gap_mask],
-        duration=gaps[gap_mask],
-        description=out_annot_name,
-        orig_time=raw.annotations.orig_time,
-    )
-
-
 def coregister(
     raw_edf,
     fiducials="estimated",  # get fiducials from fsaverage
@@ -664,7 +598,10 @@ class LosslessPipeline:
         df = df.drop_duplicates(subset=["onset", "duration"])
 
         annotations = mne.Annotations(
-            df["onset"], df["duration"], df["description"], orig_time=self.raw.annotations.orig_time
+            df["onset"],
+            df["duration"],
+            df["description"],
+            orig_time=self.raw.annotations.orig_time,
         )
         self.raw.set_annotations(self.raw.annotations + annotations)
 
@@ -1037,10 +974,6 @@ class LosslessPipeline:
         logger.info(f"📋 LOSSLESS: Uncorrelated epochs: {bad_epoch_inds}")
         self.flags["epoch"].add_flag_cat("low_r", bad_epoch_inds, epochs)
 
-    def flag_epoch_gap(self):
-        """Flag small time periods between pylossless annotations."""
-        annots = marks_flag_gap(self.raw, self.config["epoch_gap"]["min_gap_ms"])
-        self.raw.set_annotations(self.raw.annotations + annots)
 
     @lossless_logger
     def run_ica(self, run):
@@ -1230,20 +1163,14 @@ class LosslessPipeline:
         # 9. Calculate nearest neighbour R values for epochs
         self.flag_epoch_low_r(message="Flagging Uncorrelated epochs")
 
-        # 10. Flag very small time periods between flagged time
-        self.flag_epoch_gap()
-
-        # 11. Run ICA
+        # 10. Run ICA
         self.run_ica("run1", message="Running Initial ICA")
 
-        # 12. Calculate IC SD
+        # 11. Calculate IC SD
         self.flag_epoch_ic_sd1(message="Flagging time periods with noisy" " IC's.")
 
-        # 13. TODO: integrate labels from IClabels to self.flags["ic"]
+        # 12. TODO: integrate labels from IClabels to self.flags["ic"]
         self.run_ica("run2", message="Running Final ICA.")
-
-        # 14. Flag very small time periods between flagged time
-        self.flag_epoch_gap()
 
     def run_dataset(self, paths):
         """Run a full dataset.

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -974,7 +974,6 @@ class LosslessPipeline:
         logger.info(f"📋 LOSSLESS: Uncorrelated epochs: {bad_epoch_inds}")
         self.flags["epoch"].add_flag_cat("low_r", bad_epoch_inds, epochs)
 
-
     @lossless_logger
     def run_ica(self, run):
         """Run ICA.


### PR DESCRIPTION
Closes #75 

Now, instead of having several 1-second annotaitons + < 1 -second gap annotations:

![Screen Shot 2023-11-07 at 12 04 34 PM](https://github.com/lina-usc/pylossless/assets/52462026/4c578903-cfc6-4e2a-a7af-42f76488626d)


You have this 1-single annotation:

![Screen Shot 2023-11-07 at 12 04 50 PM](https://github.com/lina-usc/pylossless/assets/52462026/6f793b6a-34cf-4413-889e-0daa310c22be)

Leading to a much better UX.


This also removes the need for the `flag_gap` boilerplate, which I think really was an idiosyncrasy of the MATLAB pipeline, which couldn't leverage a native annotation structure. instead of filling small (less than 1-second) "gap" annotations between two annotation of the same description, we can just merge those annotations into a single annotation.