### PR TITLE
adding format parameter to save function

### DIFF
--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -1038,7 +1038,7 @@ class LosslessPipeline:
         overwrite : bool (default False)
             whether to overwrite existing files with the same name.
         format : str (default "EDF")
-            The format to use for saving the raw data. Can be 'auto',
+            The format to use for saving the raw data. Can be ``"auto"``,
             'FIF', 'EDF', 'BrainVision', 'EEGLAB'.
         event_id : dict | None (default None)
             Dictionary mapping annotation descriptions to event codes.

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -1278,7 +1278,7 @@ class LosslessPipeline:
 
         # Final check to ensure we have at least one event
         if not combined_event_id:
-            print("Warning: No valid events or annotations could be processed.")
+            warn("Warning: No valid events or annotations could be processed.")
             return None
 
         return combined_event_id

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -1037,8 +1037,9 @@ class LosslessPipeline:
             path of the derivatives folder to save the file to.
         overwrite : bool (default False)
             whether to overwrite existing files with the same name.
-        format : str (default "auto")
-            The format to use for saving the raw data. Can be 'auto', 'fif', 'edf', etc.
+        format : str (default "EDF")
+            The format to use for saving the raw data. Can be 'auto',
+            'FIF', 'EDF', 'BrainVision', 'EEGLAB'.
         """
         mne_bids.write_raw_bids(
             self.raw,

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -1256,7 +1256,7 @@ class LosslessPipeline:
             # Get existing events and their IDs
             _, event_id = mne.events_from_annotations(self.raw)
         except ValueError as e:
-            print(f"Warning: No events found in raw data. Error: {e}")
+            warn(f"Warning: No events found in raw data. Error: {e}")
             event_id = {}
 
         # Check if there are any annotations

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -1261,7 +1261,7 @@ class LosslessPipeline:
 
         # Check if there are any annotations
         if len(self.raw.annotations) == 0 and not event_id:
-            print("Warning: No events or annotations found in the raw data.")
+            warn("Warning: No events or annotations found in the raw data.")
             return None
 
         # Initialize the combined event ID dictionary with existing events

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -1250,7 +1250,7 @@ class LosslessPipeline:
         dict or None
             A combined dictionary of event IDs, including both existing markers
             and new ones from annotations.
-            Returns None if no events or annotations are found.
+            Returns ``None`` if no events or annotations are found.
         """
         try:
             # Get existing events and their IDs

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -1254,7 +1254,7 @@ class LosslessPipeline:
         """
         try:
             # Get existing events and their IDs
-            events, event_id = mne.events_from_annotations(self.raw)
+            _, event_id = mne.events_from_annotations(self.raw)
         except ValueError as e:
             print(f"Warning: No events found in raw data. Error: {e}")
             event_id = {}

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -1039,7 +1039,7 @@ class LosslessPipeline:
             whether to overwrite existing files with the same name.
         format : str (default "EDF")
             The format to use for saving the raw data. Can be ``"auto"``,
-            'FIF', 'EDF', 'BrainVision', 'EEGLAB'.
+            ``"FIF"``, ``"EDF"``, ``"BrainVision"``, ``"EEGLAB"``.
         event_id : dict | None (default None)
             Dictionary mapping annotation descriptions to event codes.
         """

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -1262,7 +1262,7 @@ class LosslessPipeline:
         # Check if there are any annotations
         if len(self.raw.annotations) == 0 and not event_id:
             warn("Warning: No events or annotations found in the raw data.")
-            return None
+            return
 
         # Initialize the combined event ID dictionary with existing events
         combined_event_id = event_id.copy()

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -1254,7 +1254,7 @@ class LosslessPipeline:
         """
         try:
             # Get existing events and their IDs
-            _, event_id = mne.events_from_annotations(self.raw)
+            event_id = mne.events_from_annotations(self.raw)[1]
         except ValueError as e:
             warn(f"Warning: No events found in raw data. Error: {e}")
             event_id = {}

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -1282,4 +1282,3 @@ class LosslessPipeline:
             return
 
         return combined_event_id
-

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -1028,7 +1028,7 @@ class LosslessPipeline:
 
         # icsd_epoch_flags=padflags(raw, icsd_epoch_flags,1,'value',.5);
 
-    def save(self, derivatives_path, overwrite=False):
+    def save(self, derivatives_path, overwrite=False, format="EDF"):
         """Save the file at the end of the pipeline.
 
         Parameters
@@ -1037,12 +1037,14 @@ class LosslessPipeline:
             path of the derivatives folder to save the file to.
         overwrite : bool (default False)
             whether to overwrite existing files with the same name.
+        format : str (default "auto")
+            The format to use for saving the raw data. Can be 'auto', 'fif', 'edf', etc.
         """
         mne_bids.write_raw_bids(
             self.raw,
             derivatives_path,
             overwrite=overwrite,
-            format="EDF",
+            format=format,
             allow_preload=True,
         )
         # TODO: address derivatives support in MNE bids.

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -1279,7 +1279,7 @@ class LosslessPipeline:
         # Final check to ensure we have at least one event
         if not combined_event_id:
             warn("Warning: No valid events or annotations could be processed.")
-            return None
+            return
 
         return combined_event_id
 

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -1028,7 +1028,7 @@ class LosslessPipeline:
 
         # icsd_epoch_flags=padflags(raw, icsd_epoch_flags,1,'value',.5);
 
-    def save(self, derivatives_path, overwrite=False, format="EDF"):
+    def save(self, derivatives_path, overwrite=False, format="EDF", event_id=None):
         """Save the file at the end of the pipeline.
 
         Parameters
@@ -1040,6 +1040,8 @@ class LosslessPipeline:
         format : str (default "EDF")
             The format to use for saving the raw data. Can be 'auto',
             'FIF', 'EDF', 'BrainVision', 'EEGLAB'.
+        event_id : dict | None (default None)
+            Dictionary mapping annotation descriptions to event codes.
         """
         mne_bids.write_raw_bids(
             self.raw,
@@ -1047,6 +1049,7 @@ class LosslessPipeline:
             overwrite=overwrite,
             format=format,
             allow_preload=True,
+            event_id=event_id,
         )
         # TODO: address derivatives support in MNE bids.
         # use shutils ( or pathlib?) to rename file with ll suffix


### PR DESCRIPTION
This pull request adds a `format` and 'event_id' parameter to the `pipeline.save()` method in `pipeline.py`.  A new pipeline method gets event_ids from existing event codes and annotations. 

### Changes Made
- Added a `format` parameter to the `pipeline.save()` method in `pipeline.py`
- Added a `event_id` parameter to the `pipeline.save()` method in `pipeline.py`
- Updated relevant documentation to reflect these new parameters
- Existing event codes retain their numeric values (i.e., 10003) and event codes derived from annotations are numbered after the highest existing event code.
- Ensured backward compatibility with existing code

### Motivation
When working with non-EDF formats, such as BrainVision, the current implementation leads to errors. This change allows for greater flexibility in output formats, improving the library's usability across different EEG data types. The event_id field perserves existing event codes, otherwise arbritary codes are assigned.

### Potential error messages these changes address:
ValueError: The provided raw data contains annotations, but "event_id" does not contain entries for all annotation descriptions. The following entries are missing: BAD_LL_noisy, BAD_LL_noisy_ICs