### PR TITLE
Maint fixes

### DIFF
--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -12,9 +12,9 @@ jobs:
   test:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
       - name: Install Pylossless & Deps

--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -23,10 +23,6 @@ jobs:
         run: pip install -r requirements_testing.txt
       - name: Install QC depedencies
         run: pip install -r requirements_qc.txt
-      - name: install openneuro
-        run: pip install openneuro-py
-      - name: install pytorch
-        run: pip install torch
       - name: Test Pipeline
         run: |
           coverage run -m pytest

--- a/pylossless/conftest.py
+++ b/pylossless/conftest.py
@@ -16,7 +16,7 @@ import pytest
 
 # XXX: This is a temporary fix to suppress a warning from MNE-ICAlabel
 # This can be removed once MNE-ICAlabel 0.7 is released
-@pytest.mark.filterwarnings("ignore:.*You are using.*:FutureWarning")
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.fixture(scope="session")
 def pipeline_fixture():
     """Return a namedTuple containing MNE eyetracking raw data and events."""

--- a/pylossless/conftest.py
+++ b/pylossless/conftest.py
@@ -13,6 +13,7 @@ from pylossless.datasets import load_openneuro_bids
 
 import pytest
 
+
 # XXX: This is a temporary fix to suppress a warning from MNE-ICAlabel
 # This can be removed once MNE-ICAlabel 0.7 is released
 @pytest.mark.filterwarnings("ignore:.*weights_only.*:FutureWarning")

--- a/pylossless/conftest.py
+++ b/pylossless/conftest.py
@@ -16,7 +16,7 @@ import pytest
 
 # XXX: This is a temporary fix to suppress a warning from MNE-ICAlabel
 # This can be removed once MNE-ICAlabel 0.7 is released
-@pytest.mark.filterwarnings("ignore:.*weights_only.*:FutureWarning")
+@pytest.mark.filterwarnings("ignore:.*You are using.*:FutureWarning")
 @pytest.fixture(scope="session")
 def pipeline_fixture():
     """Return a namedTuple containing MNE eyetracking raw data and events."""

--- a/pylossless/conftest.py
+++ b/pylossless/conftest.py
@@ -13,7 +13,9 @@ from pylossless.datasets import load_openneuro_bids
 
 import pytest
 
-
+# XXX: This is a temporary fix to suppress a warning from MNE-ICAlabel
+# This can be removed once MNE-ICAlabel 0.7 is released
+@pytest.mark.filterwarnings("ignore:.*weights_only.*:FutureWarning")
 @pytest.fixture(scope="session")
 def pipeline_fixture():
     """Return a namedTuple containing MNE eyetracking raw data and events."""

--- a/pylossless/dash/tests/test_topo_viz.py
+++ b/pylossless/dash/tests/test_topo_viz.py
@@ -68,7 +68,7 @@ def test_GridTopoPlot():
 
 # chromedriver: https://chromedriver.storage.googleapis.com/
 #               index.html?path=114.0.5735.90/
-@pytest.mark.xfail(reason="an issue with chromedriver causes failure. Need to debug.")
+@pytest.mark.skip(reason="an issue with chromedriver causes failure. Need to debug.")
 def test_TopoViz(dash_duo):
     """Test TopoViz."""
     raw, ica = get_raw_ica()

--- a/pylossless/tests/test_rejection.py
+++ b/pylossless/tests/test_rejection.py
@@ -7,6 +7,8 @@ import pytest
 import pylossless as ll
 
 
+# XXX: This filter can be removed once MNE-ICAlabel 0.7 is released
+@pytest.mark.filterwarnings("ignore:.*weights_only.*:FutureWarning")
 @pytest.mark.parametrize("clean_ch_mode", [None, "drop", "interpolate"])
 def test_rejection_policy(clean_ch_mode, pipeline_fixture):
     """Test the rejection policy."""

--- a/pylossless/tests/test_rejection.py
+++ b/pylossless/tests/test_rejection.py
@@ -8,7 +8,7 @@ import pylossless as ll
 
 
 # XXX: This filter can be removed once MNE-ICAlabel 0.7 is released
-@pytest.mark.filterwarnings("ignore:.*weights_only.*:FutureWarning")
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("clean_ch_mode", [None, "drop", "interpolate"])
 def test_rejection_policy(clean_ch_mode, pipeline_fixture):
     """Test the rejection policy."""

--- a/pylossless/tests/test_simulated.py
+++ b/pylossless/tests/test_simulated.py
@@ -26,7 +26,8 @@ pipeline.raw = raw_sim
 @pytest.mark.parametrize("pipeline", [(pipeline)])
 def test_simulated_raw(pipeline):
     """Test pipeline on simulated EEG."""
-    pipeline._check_sfreq()
+    with pytest.warns(RuntimeWarning, match="sampling frequency"):
+        pipeline._check_sfreq()
     # This file should have been downsampled
     assert pipeline.raw.info["sfreq"] == 600
     # FIND NOISY EPOCHS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,6 @@ filterwarnings = ["error",
  # deprecation in dash-testing that needs to be reported
 "ignore::DeprecationWarning",
 # TODO MNE deprecation that wont effect us. remove if we ever bump to mne 1.7
-"ignore:The current default of copy=False will change to copy=True in 1.7.",]
+"ignore:The current default of copy=False will change to copy=True in 1.7.",
+"ignore:You are using",
+]


### PR DESCRIPTION
This fixes a few things and we'll see if the CI's tell us whether we need to fix a few more.


1. As of yesterday, torch 2.4 was released, and a new `FutureWarning` was being triggered in torch by MNE-ICAlabel. I've submitted a fix to `MNE-ICALabel` already, but in the meantime I'm just filtering out the warning in our tests. Once MNE-ICALabel .7 is released we can remove the `pytest.mark.filterwarnings`
2.  One of our tests was rightfully throwing a warning because we were downsampling our test file with a non-integer sampling frequency to an integer sampling frequency. I'm honestly surprised our tests weren't failing because of this before! (EDIT: this error was being filtered in our pytest.ini file, but for some reason it is not being respected on the CI's).
3. Removed some manual installs of `openneuro-py` and `torch` since those packages are now listed in `requirements_testing.txt`
4.  We currently have a `pytest.mark.xfail` on `test_TopoViz`, because it was failing due to some issue with chrome driver. The failing test also causes the CI's to hang for a really long time. In the mean time I'm marking this test to be skipped, until we can fix it.