### PR TITLE
FIX: Don't import optional deps at the top-level

### DIFF
--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -19,6 +19,9 @@ jobs:
           python-version: "3.9"
       - name: Install Pylossless & Deps
         run: pip install -e .
+      - name: Test import
+        run: |
+          python -c "import pylossless"
       - name: Install testing dependencies
         run: pip install -r requirements_testing.txt
       - name: Install QC depedencies

--- a/pylossless/datasets/datasets.py
+++ b/pylossless/datasets/datasets.py
@@ -2,7 +2,6 @@ from time import sleep
 from pathlib import Path
 
 import mne_bids
-import openneuro
 
 import pylossless as ll
 
@@ -31,6 +30,8 @@ def load_openneuro_bids(subject="pd6"):
     dataset is from the "UC San Diego Resting State EEG Data from Patients with
     Parkinson's Disease" study, curated by Alexander Rockhill.
     """
+    openneuro = ll.utils.import_optional_dependency("openneuro")
+
     config = ll.config.Config()
     config.load_default()
     config["project"]["bids_montage"] = ""

--- a/pylossless/tests/test_utils.py
+++ b/pylossless/tests/test_utils.py
@@ -1,19 +1,4 @@
-import re
-from pathlib import Path
-
 import pytest
-
-@pytest.mark.skip(reason="This test is not yet implemented.")
-def test_toplevel_imports():
-    """Test that there are no optional dependencies at the top level."""
-    optional_deps = []
-    with (Path(".").parent.parent.parent / "requirements.txt") as file:
-        for line in file.read_text().split("\n"):
-            if line and not line.startswith("#"):
-                # regex for any one or two of the characters <, >, =, !
-                regex = r"[<>=!]{1,2}"
-                optional_deps.append(re.split(regex, line)[0])
-    pass
 
 def test_import_optional_dependency():
     """Test the import_optional_dependency function."""

--- a/pylossless/tests/test_utils.py
+++ b/pylossless/tests/test_utils.py
@@ -1,0 +1,33 @@
+import re
+from pathlib import Path
+
+import pytest
+
+@pytest.mark.skip(reason="This test is not yet implemented.")
+def test_toplevel_imports():
+    """Test that there are no optional dependencies at the top level."""
+    optional_deps = []
+    with (Path(".").parent.parent.parent / "requirements.txt") as file:
+        for line in file.read_text().split("\n"):
+            if line and not line.startswith("#"):
+                # regex for any one or two of the characters <, >, =, !
+                regex = r"[<>=!]{1,2}"
+                optional_deps.append(re.split(regex, line)[0])
+    pass
+
+def test_import_optional_dependency():
+    """Test the import_optional_dependency function."""
+    from pylossless.utils import check
+
+    # Test the case where the package is not installed.
+    with pytest.raises(ImportError, match="Missing optional dependency 'astropy'."):
+        # choosing a package that will probably never be added to the requirements!
+        check.import_optional_dependency("astropy")
+
+    # Test the case where the package is installed.
+    mne = check.import_optional_dependency("mne", raise_error=False)
+    assert mne is not None
+
+    # Test the where case package is not installed but we don't want to raise an error.
+    astropy = check.import_optional_dependency("astropy", raise_error=False)
+    assert astropy is None

--- a/pylossless/utils/__init__.py
+++ b/pylossless/utils/__init__.py
@@ -1,2 +1,3 @@
 from ._utils import _icalabel_to_data_frame, _report_flagged_epochs
+from .check import import_optional_dependency
 from .html import _get_ics, _sum_flagged_times, _create_html_details

--- a/pylossless/utils/check.py
+++ b/pylossless/utils/check.py
@@ -1,0 +1,52 @@
+import importlib
+
+
+# A mapping from import name to package name (on PyPI) when the package name
+# is different.
+_INSTALL_MAPPING = {
+    "codespell_lib": "codespell",
+    "openneuro": "openneuro-py",
+    "pytest_cov": "pytest-cov",
+    "sklearn": "scikit-learn",
+}
+
+
+def import_optional_dependency(
+    name,
+    extra=None,
+    raise_error=True,
+):
+    """Import an optional dependency.
+
+    By default, if a dependency is missing an ImportError with a nice message will be
+    raised.
+
+    Parameters
+    ----------
+    name : str
+        The module name.
+    extra : str | None
+        Additional text to include in the ImportError message. Default is None, which
+        means no additional text.
+    raise_error : bool
+        What to do when a dependency is not found.
+        * True : Raise an ImportError.
+        * False: Return None.
+
+    Returns
+    -------
+    module : Module | None
+        The imported module when found.
+        None is returned when the package is not found and raise_error is False.
+    """
+    package_name = _INSTALL_MAPPING.get(name, name)
+    install_name = package_name if package_name is not None else name
+    if importlib.util.find_spec(name) is None:
+        if raise_error:
+            raise ImportError(
+                f"Missing optional dependency '{install_name}'. {extra} Use pip or "
+                f"conda to install {install_name}."
+            )
+        else:
+            return None
+    return importlib.import_module(name)

--- a/pylossless/utils/check.py
+++ b/pylossless/utils/check.py
@@ -40,12 +40,11 @@ def import_optional_dependency(
         None is returned when the package is not found and raise_error is False.
     """
     package_name = _INSTALL_MAPPING.get(name, name)
-    install_name = package_name if package_name is not None else name
     if importlib.util.find_spec(name) is None:
         if raise_error:
             raise ImportError(
-                f"Missing optional dependency '{install_name}'. {extra} Use pip or "
-                f"conda to install {install_name}."
+                f"Missing optional dependency '{package_name}'. {extra} Use pip or "
+                f"conda to install {package_name}."
             )
         else:
             return None


### PR DESCRIPTION
#138 imported `openneuro` at the top of the `datasets` module, but `openneuro-py` is not a hard dependency of pylossless.

This PR creates a soft import function that gets called only if/when a user calls the function in `pylossless.datasets` that needs `openneuro-py`, and raises an informative error if they don't have it installed.

This will likely become handy if we need to do similar soft imports in the future.