### PR TITLE
MAINT: Drop black, update pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,4 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
-    hooks:
-      - id: black
-        args: [--quiet]
-        files: ^pylossless/
-
   # Ruff linter
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.286

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,8 +1,33 @@
 Contributing
-==============
+============
 
 We are glad you are here! Contributions to this package are always welcome.
 Read on to learn more about the contribution process and package design.
+
+Setting up your development environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+To get started, you will need to clone the pyLossless repository and install
+the package in development mode. This will allow you to make changes to the
+package and see the changes reflected in your python environment.
+
+This assumes that you have already forked and cloned the pyLossless repository,
+and that you have navigated to the root of the repository in your terminal.
+
+.. code-block:: console
+
+   $ pip install --editable ./pylossless
+   $ pip install -r requirements_testing.txt
+   $ pip install -r docs/requirements_doc.txt
+
+Install Pre-Commit hooks
+^^^^^^^^^^^^^^^^^^^^^^^^
+We use `pre-commit <https://pre-commit.com/>`__ to run code checks before
+committing changes. To install the pre-commit hooks, run the following command:
+
+.. code-block:: console
+
+   $ pre-commit install --install-hooks
+
 
 Building and Contributing to the Docs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -91,8 +91,7 @@ git repository directory, before running the code below:
    $ pip install -r docs/requirements_doc.txt
    $ pre-commit run -a
 
-PyLossless uses `black <https://github.com/psf/black>`_ style formatting. If you are
-using Visual Studio Code, you can also install the black extension to automatically
+PyLossless uses `ruff <https://docs.astral.sh/ruff/>`_ style formatting. If you are
+using Visual Studio Code, you can also install the ruff extension to automatically
 format your code. See the instructions at this
-`link 
-<https://dev.to/adamlombard/how-to-use-the-black-python-code-formatter-in-vscode-3lo0>`_
+`link <https://docs.astral.sh/ruff/editors/setup/>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,6 @@ ignore-decorators = [
     "setter",
 ]
 
-[tool.black]
-exclude = "(dist/)|(build/)|(examples/)|(.*\\.ipynb)" # Exclude build artifacts and notebooks
-
 [tool.pytest.ini_options]
 filterwarnings = ["error", 
 # error on warning except the non-int sample freq warning, which we want to be raised

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -1,4 +1,3 @@
-black
 codespell
 dash[testing]
 numpydoc


### PR DESCRIPTION
We already use `ruff` to enforce style so `black` is a dead dependency.  dropped it and removed it from the `pre-commit hook`. While I was at it I updated the docs with instructions for installing the hooks. 