### PR TITLE
Test on Windows, Linux, MacOS Intel

### DIFF
--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -41,7 +41,8 @@ jobs:
       - name: Test Pipeline
         run: |
           coverage run -m pytest
-      - name: Upload coverage to codecov
+      - name: Upload coverage to codecov (Only do this for the ubuntu-latest job)
+        if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v3
         with:
           token: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -10,7 +10,16 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest # arm64 (Apple Silicon)
+          - macos-13  # latest Intel release
+          - windows-latest
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.9

--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -26,6 +26,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.9"
+      - name: Force numpy < 2 on MacOS Intel
+        if: matrix.os == 'macos-13'
+        run: pip install 'numpy<2'
       - name: Install Pylossless & Deps
         run: pip install -e .
       - name: Test import

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ for extra, req_file in extras.items():
     extras_require[extra] = requirements_extra
 
 this_directory = Path(__file__).parent
-long_description = (this_directory / "README.md").read_text()
+long_description = (this_directory / "README.md").read_text(encoding="utf-8")
 
 qc_entry_point = ["pylossless_qc=pylossless.dash.pylossless_qc:main"]
 setup(


### PR DESCRIPTION
This makes sure we test our CI's on the major platforms (Linux, Windows, macOS). For macOS we are testing arm64 and Intel.

I suspect we may see a bug with installing pylossless on windows that users have been reporting.