### PR TITLE
MAINT, FIX: explicitly install pylossless in RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,3 +21,5 @@ python:
       - requirements: requirements.txt
       - requirements: docs/requirements_doc.txt
       - requirements: requirements_testing.txt
+      # Make sure we install the package itself
+      - requirements: .


### PR DESCRIPTION
Let's see if this works... Since #154, readthedocs fails because `importlib.metadata.version` fails within the readthedocs build. I guess we never explicitly installed Pylossless in our RTD build... 

ref: https://stackoverflow.com/questions/75922593/sphinx-readthedocs-and-package-version

I have to test this on main since RTD is only triggered once the tests pass on main. So self-merging.