### PR TITLE
FIX, DOC: Pipeline methods shouldn't accept just any instance of raw

### DIFF
--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -776,13 +776,16 @@ class LosslessPipeline:
         Parameters
         ----------
         epochs : mne.Epochs | None
-            an instance of mne.Epochs.
+            An instance of :class:`mne.Epochs`, or ``None``. If ``None``, then
+            :attr:`pylossless.LosslessPipeline.raw` should be set, and this
+            method will call :meth:`pylossless.LosslessPipeline.get_epochs`
+            to create epochs to use for outlier detection.
         picks : str (default "eeg")
             Channels to include in the outlier detection process. You can pass any
             argument that is valid for the :meth:`~mne.Epochs.pick` method, but
             you should avoid passing a mix of channel types with differing units of
             measurement (e.g. EEG and MEG), as this would likely lead to incorrect
-            outlier detection (e.g. all MEG channels would be flagged as outliers).
+            outlier detection (e.g. all EEG channels would be flagged as outliers).
 
         Returns
         -------

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -795,12 +795,24 @@ class LosslessPipeline:
         Notes
         -----
         - This method is used to detect channels that are so noisy that they
-            should be left out of the robust average rereference process.
+          should be left out of the robust average rereference process.
+
+        Examples
+        --------
+        >>> import mne
+        >>> import pylossless as ll
+        >>> config = ll.Config().load_default()
+        >>> pipeline = ll.LosslessPipeline(config=config)
+        >>> fname = mne.datasets.sample.data_path() / "MEG/sample/sample_audvis_raw.fif"
+        >>> raw = mne.io.read_raw(fname)
+        >>> epochs = mne.make_fixed_length_epochs(raw, preload=True)
+        >>> chs_to_leave_out = pipeline.find_outlier_chs(epochs=epochs)
         """
         # TODO: Reuse _detect_outliers here.
         logger.info("🔍 Detecting channels to leave out of reference.")
         if epochs is None:
-            epochs = self.get_epochs(rereference=False, picks=picks)
+            epochs = self.get_epochs(rereference=False)
+        epochs = epochs.copy().pick(picks=picks)
         epochs_xr = epochs_to_xr(epochs, kind="ch")
 
         # Determines comically bad channels,

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -770,7 +770,7 @@ class LosslessPipeline:
         )
         self.flags[flag_dim].add_flag_cat("volt_std", above_threshold, epochs)
 
-    def find_outlier_chs(self, epochs, picks="eeg"):
+    def find_outlier_chs(self, epochs=None, picks="eeg"):
         """Detect outlier Channels to leave out of rereference.
 
         Parameters

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -798,7 +798,6 @@ class LosslessPipeline:
         logger.info("🔍 Detecting channels to leave out of reference.")
         if epochs is None:
             epochs = self.get_epochs(rereference=False, picks=picks)
-                "inst must be an instance of mne.Epochs," f" but got {type(inst)}."
         epochs_xr = epochs_to_xr(epochs, kind="ch")
 
         # Determines comically bad channels,

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -771,16 +771,36 @@ class LosslessPipeline:
         self.flags[flag_dim].add_flag_cat("volt_std", above_threshold, epochs)
 
     def find_outlier_chs(self, inst, picks="eeg"):
-        """Detect outlier Channels to leave out of rereference."""
+        """Detect outlier Channels to leave out of rereference.
+
+        Parameters
+        ----------
+        inst : mne.Epochs
+            an instance of mne.Epochs.
+        picks : str (default "eeg")
+            Channels to include in the outlier detection process. You can pass any
+            argument that is valid for the :meth:`~mne.Epochs.pick` method, but
+            you should avoid passing a mix of channel types with differing units of
+            measurement (e.g. EEG and MEG), as this would likely lead to incorrect
+            outlier detection (e.g. all MEG channels would be flagged as outliers).
+
+        Returns
+        -------
+        list
+            a list of channel names that are considered outliers.
+
+        Notes
+        -----
+        - This method is used to detect channels that are so noisy that they
+            should be left out of the robust average rereference process.
+        """
         # TODO: Reuse _detect_outliers here.
         logger.info("🔍 Detecting channels to leave out of reference.")
         if isinstance(inst, mne.Epochs):
             epochs = inst
-        elif isinstance(inst, mne.io.Raw):
-            epochs = self.get_epochs(rereference=False, picks=picks)
         else:
             raise TypeError(
-                "inst must be an MNE Raw or Epochs object," f" but got {type(inst)}."
+                "inst must be an instance of mne.Epochs," f" but got {type(inst)}."
             )
         epochs_xr = epochs_to_xr(epochs, kind="ch")
 

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -770,12 +770,12 @@ class LosslessPipeline:
         )
         self.flags[flag_dim].add_flag_cat("volt_std", above_threshold, epochs)
 
-    def find_outlier_chs(self, inst, picks="eeg"):
+    def find_outlier_chs(self, epochs, picks="eeg"):
         """Detect outlier Channels to leave out of rereference.
 
         Parameters
         ----------
-        inst : mne.Epochs
+        epochs : mne.Epochs | None
             an instance of mne.Epochs.
         picks : str (default "eeg")
             Channels to include in the outlier detection process. You can pass any
@@ -796,12 +796,9 @@ class LosslessPipeline:
         """
         # TODO: Reuse _detect_outliers here.
         logger.info("🔍 Detecting channels to leave out of reference.")
-        if isinstance(inst, mne.Epochs):
-            epochs = inst
-        else:
-            raise TypeError(
+        if epochs is None:
+            epochs = self.get_epochs(rereference=False, picks=picks)
                 "inst must be an instance of mne.Epochs," f" but got {type(inst)}."
-            )
         epochs_xr = epochs_to_xr(epochs, kind="ch")
 
         # Determines comically bad channels,

--- a/pylossless/tests/test_pipeline.py
+++ b/pylossless/tests/test_pipeline.py
@@ -69,6 +69,7 @@ def test_find_breaks(logging):
         pipeline.find_breaks()
     Path(config_fname).unlink()  # delete config file
 
+
 def test_find_outliers():
     """Test the find_outliers method for the case that epochs is None."""
     fname = mne.datasets.sample.data_path() / 'MEG' / 'sample' / 'sample_audvis_raw.fif'

--- a/pylossless/tests/test_pipeline.py
+++ b/pylossless/tests/test_pipeline.py
@@ -78,7 +78,7 @@ def test_find_outliers():
     config = ll.config.Config().load_default()
     pipeline = ll.LosslessPipeline(config=config)
     pipeline.raw = raw
-    chs_to_leave_out = pipeline.find_outlier_chs(epochs=None)
+    chs_to_leave_out = pipeline.find_outlier_chs()
     assert chs_to_leave_out == ['EEG 001']
 
 

--- a/pylossless/tests/test_pipeline.py
+++ b/pylossless/tests/test_pipeline.py
@@ -69,6 +69,17 @@ def test_find_breaks(logging):
         pipeline.find_breaks()
     Path(config_fname).unlink()  # delete config file
 
+def test_find_outliers():
+    """Test the find_outliers method for the case that epochs is None."""
+    fname = mne.datasets.sample.data_path() / 'MEG' / 'sample' / 'sample_audvis_raw.fif'
+    raw = mne.io.read_raw_fif(fname, preload=True)
+    raw.apply_function(lambda x: x * 10, picks="EEG 001") # create an outlier
+    config = ll.config.Config().load_default()
+    pipeline = ll.LosslessPipeline(config=config)
+    pipeline.raw = raw
+    chs_to_leave_out = pipeline.find_outlier_chs(epochs=None)
+    assert chs_to_leave_out == ['EEG 001']
+
 
 def test_deprecation():
     """Test the config_name property added for deprecation."""


### PR DESCRIPTION
Following up from #212. I realized a couple things...


First of all, `isinstance(inst, mne.io.Raw)` is still _wrong_. It should have been `isinstance(inst, mne.io.BaseRaw)`.

---------------------------------------------

More importantly, I don't think that we should actually support passing a `raw` object to this method...

Because for example, if one does  `my_pipeline.find_outlier_chs(my_raw)`, then under the hood this method actually creates an epochs instance from `my_pipeline.raw` (via `pipeline.get_epochs()`), and uses _that_ in outlier detection ...

This would lead to unexpected results if `my_raw` and `my_pipeline.raw` are not the same object in memory (i.e. they are different raw objects).

Since in our codebase we never do `pipeline.find_outlier_chs(raw)`, I dont think we should support this.

Instead, I think that always expecting an instance of mne.Epochs is OK.


Marking this PR as draft because I need to make sure the new docstring renders OK, but Opening the PR now so that others have time to comment.
