### PR TITLE
RFC, WIP: proposal to add optional steps to config

### DIFF
--- a/pylossless/assets/ll_default_config_adults.yaml
+++ b/pylossless/assets/ll_default_config_adults.yaml
@@ -26,7 +26,8 @@ project:
 
 ######################## Task break detection ########################
 # See arguments definition from mne.preprocessing.annotate_breaks
-find_breaks:
+# Uncomment dict to enable task break detection with default values
+find_breaks:  # {}
 
 ############################## epoching ##############################
 epoching:
@@ -53,6 +54,12 @@ nearest_neighbors:
   n_nbr_epoch: 3
 
 ####################### Pipeline steps config ########################
+
+# The following two steps are optional and are not enabled by default.
+# Uncomment the {} to enable them with default values.
+flag_channels_fixed_threshold: # {}
+flag_epochs_fixed_threshold: # {}
+
 bridged_channels:
   bridge_trim: 40
   bridge_z: 6

--- a/pylossless/assets/ll_default_config_infants.yaml
+++ b/pylossless/assets/ll_default_config_infants.yaml
@@ -26,7 +26,8 @@ project:
 
 ######################## Task break detection ########################
 # See arguments definition from mne.preprocessing.annotate_breaks
-find_breaks:
+# Uncomment dict to enable task break detection with default values
+find_breaks:  # {}
 
 ############################## epoching ##############################
 epoching:
@@ -53,6 +54,12 @@ nearest_neighbors:
   n_nbr_epoch: 3
 
 ####################### Pipeline steps config ########################
+
+# The following two steps are optional and are not enabled by default.
+# Uncomment the {} to enable them with default values.
+flag_channels_fixed_threshold: # {}
+flag_epochs_fixed_threshold: # {}
+
 bridged_channels:
   bridge_trim: 40
   bridge_z: 6

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -721,7 +721,7 @@ class LosslessPipeline:
         for example would unpack two keyword arguments from
         mne.preprocessing.annotate_break
         """
-        if "find_breaks" not in self.config or not self.config["find_breaks"]:
+        if "find_breaks" not in self.config or self.config["find_breaks"] is None:
             return
         if not self.raw.annotations:
             logger.debug("No annotations found in raw object. Skipping find_breaks.")
@@ -861,7 +861,10 @@ class LosslessPipeline:
         with. You may need to assess a more appropriate value for your own
         data.
         """
-        if "flag_channels_fixed_threshold" not in self.config:
+        try:
+            if self.config["flag_channels_fixed_threshold"] is None:
+                return
+        except KeyError:
             return
         if "threshold" in self.config["flag_channels_fixed_threshold"]:
             threshold = self.config["flag_channels_fixed_threshold"]["threshold"]


### PR DESCRIPTION
# Request for Comment

This is another issue-as-PR, with changes in this PR serving as a  demonstration of the proposed solution.

For optional Pipeline steps like `find_breaks`, and `flag_channels_fixed_threshold`, I'm trying to think of a way to.

1. Make these steps more discoverable to users
2. Make it easier for users to run these steps with default values
3. Make it easier for users to configure these steps.
4. Hopefully(!) Standardize the way we handle these steps in the config.


## The current behavior

### `find_breaks`.

`find_breaks` is not in our default configs. Thus the user must know that this step is an option, and how to add it to the config... E.g. they have to know to add either...

```yaml
find_breaks: {}
```
or

```yaml
find_breaks: {"threshold": .0005}
```

to the config. They can't just add this step as an empty key to the config, like

```yaml
find_breaks:
```

Because  the pipeline doesn't currently know how to handle this.

### `flag_channels_fixed_threshold`.

This is not in our default configs. The user must know that this step is an option, and how to add it to the config. Unlike `find_breaks` however, simply adding this step as an empty key DOES work, e.g.:

```yaml
flag_channels_fixed_threshold:
```

will run this step with the default `threshold` value.

## Proposal

We add these optional pipeline steps as keys to our default configs, but without any values assigned to them, e.g.

```yaml
find_breaks: # {}
flag_channels_fixed_threshold: # {}
flag_epochs_fixed_threshold: # {}
```

I propose that the pipeline skip any step that exists as empty keys in the config.. thus, these steps will be skipped by default.

- Using `find_breaks` as an example, If the users want to run the step with the default values, they can do

```yaml
find_breaks: {}
```
 
- The user can further configure this step by either using flow-style syntax, e.g.

```yaml
find_breaks: {min_break_duration: 5}
```

OR block-style syntax: 

```yaml
find_breaks:
  min_break_duration: 5
```


I'm cautiously optimistic that this is an intuitive approach to our config. But comments are welcome and requested!
