### PR TITLE
bump python, test intel mac, use conda-forge

### DIFF
--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   test:
+    name: ${{ matrix.os }} · Python 3.11
     runs-on: ${{ matrix.os }}
     
     strategy:
@@ -27,7 +28,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest # arm64 (Apple Silicon)
-          - macos-14  # MacOS Sonoma Arm64 (Apple Silicon)
           - windows-latest
 
     steps:
@@ -57,10 +57,10 @@ jobs:
         with:
           detached: true
           limit-access-to-actor: true
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install Pylossless & Deps
         run: |
           pip install -e .
@@ -84,4 +84,28 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{secrets.CODECOV_TOKEN}}
+
+  test-macos-intel:
+    name: macOS 15 Intel · conda-forge
+    runs-on: macos-15-intel
+
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v3
+        with:
+          environment-file: environment.yaml
+          cache-environment: true
+      - name: Install Pylossless
+        run: python -m pip install --no-deps -e .
+      - name: Test import
+        run: python -c "import pylossless"
+      - name: Test Pipeline
+        run: python -m pytest pylossless/ --ignore=pylossless/dash
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,36 @@
+name: pylossless-ci
+channels:
+  - conda-forge
+channel_priority: strict
+dependencies:
+  - python=3.11
+  - pip
+  - numpy
+  - scipy
+  - pandas
+  - xarray
+  - pyyaml
+  - scikit-learn
+  - pytorch
+  - edfio
+  - mne-base
+  - mne-bids
+  - mne-icalabel
+  - onnxruntime
+  - amica-python
+  - codespell
+  - dash
+  - dash-bootstrap-components
+  - dash-extensions
+  - gunicorn
+  - plotly
+  - colorlover
+  - numpydoc
+  - openneuro-py
+  - pre-commit
+  - pytest
+  - pytest-cov
+  - pydocstyle
+  - ruff
+  - selenium
+  - tomli


### PR DESCRIPTION
- Bumps Python used in CI to 3.11, since 3.10 reaches EOL in October, and MNE-Python bumped their min supported version to 3.11
- Adds a CI runner for Intel Macs, which installs dips via conda-forge, since the only PyTorch wheel for Intel Macs exists on conda-forge