### PR TITLE
Xarray API change fix

### DIFF
--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -425,7 +425,7 @@ def chan_neighbour_r(epochs, nneigbr, method):
         )
         r_list.append(xr.corr(this_ch_xr, nearest_chs_xr, dim=["time"]))
 
-    c_neigbr_r = xr.concat(r_list, dim="ref_chan")
+    c_neigbr_r = xr.concat(r_list, dim="ref_chan", join="outer")
 
     if method == "max":
         m_neigbr_r = xr.apply_ufunc(np.abs, c_neigbr_r).max(dim="channel")

--- a/pylossless/tests/test_pipeline.py
+++ b/pylossless/tests/test_pipeline.py
@@ -34,6 +34,7 @@ def test_pipeline_run(pipeline_fixture):
 @pytest.mark.filterwarnings(
     "ignore:The provided ICA instance was fitted with a 'imported_eeglab'"
 )
+@pytest.mark.filterwarnings("ignore:invalid value encountered in sqrt:RuntimeWarning")
 def test_run_ica_with_amica():
     """Test running AMICA as the final ICA method when installed."""
     pytest.importorskip("amica")
@@ -45,15 +46,16 @@ def test_run_ica_with_amica():
         np.sin(2 * time),
         np.sign(np.sin(3 * time)),
         signal.sawtooth(2 * np.pi * time),
+        signal.square(5 * time),
     ]
     source_data += 0.2 * rng.standard_normal(source_data.shape)
     source_data /= source_data.std(axis=0)
     mixing = np.array(
         [
-            [1, 1, 1],
-            [0.5, 2, 1],
-            [1.5, 1, 2],
-            [1, 2, 0.5],
+            [1, 1, 1, 0.5],
+            [0.5, 2, 1, 1.5],
+            [1.5, 1, 2, 1],
+            [1, 2, 0.5, 2],
         ]
     )
     mixed_data = source_data @ mixing.T


### PR DESCRIPTION
As seen in our failing CI: https://github.com/lina-usc/pylossless/actions/runs/31141476051/job/92752104800

`FutureWarning: In a future version of xarray the default value for join will change from join='outer' to join='exact'. This change will result in the following ValueError: cannot be aligned with join='exact' because index/labels/sizes are not equal along these coordinates (dimensions): 'channel' ('channel',) The recommendation is to set join explicitly for this case.`