### PR TITLE
ENH: Add pipeline-level random seed for reproducible ICA

### DIFF
--- a/docs/source/API/config_file.rst
+++ b/docs/source/API/config_file.rst
@@ -25,6 +25,21 @@ To see examples of the Configuration files, see below:
 - `Adult Example <https://github.com/lina-usc/pylossless/blob/main/pylossless/assets/ll_default_config_adults.yaml>`_
 - `Infant Example <https://github.com/lina-usc/pylossless/blob/main/pylossless/assets/ll_default_config_infants.yaml>`_
 
+Reproducible stochastic steps
+-----------------------------
+
+The optional top-level ``random_seed`` setting controls stochastic pipeline
+steps. The default configurations set it to ``97``. A configuration from an
+older PyLossless release that does not contain this key also uses ``97`` for
+backward compatibility. Use an integer for reproducible initialization or
+``null`` to request non-deterministic initialization::
+
+    random_seed: 97
+
+A ``random_state`` specified under ``ica.ica_args.run1`` or
+``ica.ica_args.run2`` overrides ``random_seed`` for that run. See the
+:ref:`ICA configuration <ica-random-seeds>` for examples and limitations.
+
 Configuring Pipeline Steps
 --------------------------
 

--- a/docs/source/API/steps/ica.rst
+++ b/docs/source/API/steps/ica.rst
@@ -32,3 +32,44 @@ step, as the approach and definitions are identical.
             method: infomax
         fit_params:
             extended: True
+
+
+.. _ica-random-seeds:
+
+Reproducibility and random seeds
+--------------------------------
+
+PyLossless uses the top-level ``random_seed`` configuration value for stochastic
+pipeline steps. Both ICA runs inherit this value when their run-specific
+``random_state`` is omitted. The default is ``97``, preserving the behavior of
+older PyLossless versions::
+
+    random_seed: 97
+    ica:
+      ica_args:
+        run1:
+          method: fastica
+        run2:
+          method: infomax
+          fit_params:
+            extended: true
+
+Set ``random_seed: null`` to let the ICA implementation initialize
+non-deterministically. For a deliberate per-run override, set
+``random_state`` inside that run. The local value takes precedence::
+
+    random_seed: 97
+    ica:
+      ica_args:
+        run1:
+          method: fastica
+        run2:
+          method: infomax
+          random_state: 42
+          fit_params:
+            extended: true
+
+For reproducible analyses, save the resolved configuration with the derivative
+and keep the software environment fixed. A seed controls pseudo-random
+initialization; it does not guarantee bitwise-identical results across different
+library versions, numerical backends, hardware, or thread configurations.

--- a/examples/test_config.yaml
+++ b/examples/test_config.yaml
@@ -1,3 +1,7 @@
+# Global seed for stochastic pipeline steps. A run-specific ICA
+# random_state overrides this value.
+random_seed: 97
+
 aref_trim: 30
 bridged_channels:
     bridge_trim: 40

--- a/pylossless/assets/ll_default_config_adults.yaml
+++ b/pylossless/assets/ll_default_config_adults.yaml
@@ -2,6 +2,10 @@
 #ref_loc_file: derivatives/pylossless/code/misc/standard_1020_ll_ref19.elc
 #montage_info: [0.0, -16.0, 0.0, -0.02, 0.0, -1.58, 10.7, 11.5, 11.5]
 
+# Seed used by stochastic pipeline steps. Set to null for non-deterministic
+# behavior. A run-specific ica_args.<run>.random_state takes precedence.
+random_seed: 97
+
 ################## General info about the project ####################
 project:
   readme: "# Description of the dataset"

--- a/pylossless/assets/ll_default_config_infants.yaml
+++ b/pylossless/assets/ll_default_config_infants.yaml
@@ -2,6 +2,10 @@
 #ref_loc_file: derivatives/pylossless/code/misc/standard_1020_ll_ref19.elc
 #montage_info: [0.0, -16.0, 0.0, -0.02, 0.0, -1.58, 10.7, 11.5, 11.5]
 
+# Seed used by stochastic pipeline steps. Set to null for non-deterministic
+# behavior. A run-specific ica_args.<run>.random_state takes precedence.
+random_seed: 97
+
 ################## General info about the project ####################
 project:
   readme: "# Description of the dataset"

--- a/pylossless/pipeline.py
+++ b/pylossless/pipeline.py
@@ -11,6 +11,7 @@ from copy import deepcopy
 from pathlib import Path
 from functools import partial
 from importlib.metadata import version
+from numbers import Integral
 
 # Math and data structures
 import numpy as np
@@ -1214,6 +1215,37 @@ class LosslessPipeline:
         )
         self.flags["epoch"].add_flag_cat("uncorrelated", bad_epoch_inds, epochs)
 
+    def _get_ica_kwargs(self, run):
+        """Resolve ICA parameters for one pipeline run.
+
+        The run-specific ``random_state`` has the highest precedence. If it is
+        omitted, the pipeline-level ``random_seed`` is used. Configurations
+        created before ``random_seed`` was introduced retain the historical
+        seed of 97.
+        """
+        if run not in ("run1", "run2"):
+            raise ValueError("The `run` argument must be 'run1' or 'run2'")
+
+        ica_kwargs = dict(self.config["ica"]["ica_args"][run])
+        if "random_state" not in ica_kwargs:
+            random_seed = self.config.get("random_seed", 97)
+            if random_seed is not None and (
+                isinstance(random_seed, bool) or not isinstance(random_seed, Integral)
+            ):
+                raise TypeError("`random_seed` must be an integer or None")
+            # Normalize NumPy integer scalars so saved runtime parameters remain
+            # straightforward to serialize and compare.
+            if random_seed is not None:
+                random_seed = int(random_seed)
+            ica_kwargs["random_state"] = random_seed
+
+        method = ica_kwargs.get("method", "fastica")
+        if isinstance(method, str) and method.lower() == "amica":
+            ica_kwargs.pop("method")
+        elif "max_iter" not in ica_kwargs:
+            ica_kwargs["max_iter"] = "auto"
+        return method, ica_kwargs
+
     @lossless_logger
     def run_ica(self, run, picks="eeg"):
         """Run ICA.
@@ -1226,15 +1258,14 @@ class LosslessPipeline:
             `mne_icalabel`.
         picks : str (default "eeg")
             Type of channels to pick.
+
+        Notes
+        -----
+        When ``random_state`` is absent from the selected run's ``ica_args``,
+        the pipeline-level ``random_seed`` is passed to the ICA implementation.
+        A run-specific ``random_state`` always overrides the global seed.
         """
-        ica_kwargs = dict(self.config["ica"]["ica_args"][run])
-        method = ica_kwargs.get("method", "fastica")
-        if isinstance(method, str) and method.lower() == "amica":
-            ica_kwargs.pop("method")
-        elif "max_iter" not in ica_kwargs:
-            ica_kwargs["max_iter"] = "auto"
-        if "random_state" not in ica_kwargs:
-            ica_kwargs["random_state"] = 97
+        method, ica_kwargs = self._get_ica_kwargs(run)
 
         epochs = self.get_epochs(picks=picks)
         if isinstance(method, str) and method.lower() == "amica":

--- a/pylossless/tests/test_random_seed.py
+++ b/pylossless/tests/test_random_seed.py
@@ -1,0 +1,141 @@
+from copy import deepcopy
+
+import mne
+import numpy as np
+import pytest
+
+import pylossless as ll
+
+
+def _pipeline(random_seed=97):
+    config = ll.Config().load_default()
+    config["random_seed"] = random_seed
+    return ll.LosslessPipeline(config=config)
+
+
+def test_default_configs_define_random_seed():
+    """Adult and infant defaults should opt into reproducible ICA."""
+    assert ll.Config().load_default("adults")["random_seed"] == 97
+    assert ll.Config().load_default("infants")["random_seed"] == 97
+
+
+@pytest.mark.parametrize("run", ["run1", "run2"])
+def test_global_random_seed_is_inherited_by_ica_runs(run):
+    """Both ICA runs should inherit the pipeline-level seed."""
+    _, kwargs = _pipeline(random_seed=123)._get_ica_kwargs(run)
+    assert kwargs["random_state"] == 123
+
+
+def test_run_specific_random_state_takes_precedence():
+    """A deliberate local override should win over the global seed."""
+    pipeline = _pipeline(random_seed=123)
+    pipeline.config["ica"]["ica_args"]["run2"]["random_state"] = 456
+
+    _, run1_kwargs = pipeline._get_ica_kwargs("run1")
+    _, run2_kwargs = pipeline._get_ica_kwargs("run2")
+
+    assert run1_kwargs["random_state"] == 123
+    assert run2_kwargs["random_state"] == 456
+
+
+def test_legacy_config_retains_historical_seed():
+    """Configs without the new key should preserve the former seed of 97."""
+    config = ll.Config().load_default()
+    del config["random_seed"]
+    pipeline = ll.LosslessPipeline(config=config)
+
+    _, kwargs = pipeline._get_ica_kwargs("run1")
+    assert kwargs["random_state"] == 97
+
+
+def test_none_requests_nondeterministic_initialization():
+    """None should be forwarded rather than replaced by the fallback seed."""
+    _, kwargs = _pipeline(random_seed=None)._get_ica_kwargs("run1")
+    assert kwargs["random_state"] is None
+
+
+@pytest.mark.parametrize("bad_seed", [True, 1.5, "97", [97]])
+def test_invalid_global_random_seed_raises(bad_seed):
+    """Invalid YAML-compatible seed values should fail before ICA fitting."""
+    pipeline = _pipeline(random_seed=bad_seed)
+    with pytest.raises(TypeError, match="random_seed.*integer or None"):
+        pipeline._get_ica_kwargs("run1")
+
+
+def test_numpy_integer_seed_is_normalized():
+    """NumPy integer scalars should be accepted and normalized to Python int."""
+    _, kwargs = _pipeline(random_seed=np.int64(12))._get_ica_kwargs("run1")
+    assert kwargs["random_state"] == 12
+    assert type(kwargs["random_state"]) is int
+
+
+def test_resolving_ica_kwargs_does_not_mutate_config():
+    """Runtime defaults must not modify the user-provided configuration."""
+    pipeline = _pipeline(random_seed=123)
+    before = deepcopy(pipeline.config)
+
+    pipeline._get_ica_kwargs("run1")
+    pipeline._get_ica_kwargs("run2")
+
+    assert pipeline.config == before
+    assert "random_state" not in pipeline.config["ica"]["ica_args"]["run1"]
+
+
+def test_random_seed_round_trip(tmp_path):
+    """The global seed should survive YAML serialization."""
+    config = ll.Config().load_default()
+    config["random_seed"] = 31415
+    path = tmp_path / "config.yaml"
+
+    config.save(path)
+    loaded = ll.Config().read(path)
+
+    assert loaded["random_seed"] == 31415
+
+
+def test_invalid_ica_run_fails_with_clear_error():
+    """An invalid run name should fail before indexing the configuration."""
+    with pytest.raises(ValueError, match="run1.*run2"):
+        _pipeline()._get_ica_kwargs("run3")
+
+@pytest.mark.filterwarnings(
+    "ignore:FastICA did not converge:sklearn.exceptions.ConvergenceWarning"
+)
+def test_global_seed_reproduces_mne_ica_fit():
+    """The same global seed should reproduce a real MNE ICA fit."""
+    rng = np.random.default_rng(123)
+    sfreq = 128.0
+    times = np.arange(0, 8, 1 / sfreq)
+    sources = np.vstack(
+        [
+            np.sin(2 * np.pi * 7 * times),
+            np.sign(np.sin(2 * np.pi * 3 * times)),
+            rng.normal(size=times.size),
+            np.sin(2 * np.pi * 13 * times),
+        ]
+    )
+    mixing = np.array(
+        [
+            [1.0, 0.3, 0.2, 0.4],
+            [0.2, 1.0, 0.4, 0.1],
+            [0.5, 0.2, 1.0, 0.3],
+            [0.1, 0.4, 0.2, 1.0],
+        ]
+    )
+    info = mne.create_info(["Fz", "Cz", "Pz", "Oz"], sfreq, "eeg")
+    raw = mne.io.RawArray(mixing @ sources, info, verbose=False)
+    raw.filter(1, 40, verbose=False)
+
+    unmixing_matrices = []
+    for _ in range(2):
+        pipeline = _pipeline(random_seed=123)
+        pipeline.config["epoching"]["epochs_args"].update(tmax=1, baseline=None)
+        pipeline.config["ica"]["ica_args"]["run1"].update(
+            n_components=3, max_iter=1000
+        )
+        pipeline.raw = raw.copy()
+        pipeline.run_ica("run1")
+        assert pipeline.ica1.random_state == 123
+        unmixing_matrices.append(pipeline.ica1.unmixing_matrix_)
+
+    np.testing.assert_allclose(unmixing_matrices[0], unmixing_matrices[1])

--- a/pylossless/tests/test_random_seed.py
+++ b/pylossless/tests/test_random_seed.py
@@ -66,7 +66,7 @@ def test_numpy_integer_seed_is_normalized():
     """NumPy integer scalars should be accepted and normalized to Python int."""
     _, kwargs = _pipeline(random_seed=np.int64(12))._get_ica_kwargs("run1")
     assert kwargs["random_state"] == 12
-    assert type(kwargs["random_state"]) is int
+    assert isinstance(kwargs["random_state"], int)
 
 
 def test_resolving_ica_kwargs_does_not_mutate_config():


### PR DESCRIPTION

## Summary

This PR adds a pipeline-level `random_seed` configuration option for reproducible ICA initialization.

Both ICA runs inherit the global seed when their run-specific `random_state` is omitted. A local `random_state` remains the highest-precedence override.

Closes #253.

## Motivation

PyLossless previously inserted the seed `97` directly inside `run_ica`. This made the default behavior deterministic, but the seed was not visible or configurable at the pipeline level.

Making the seed explicit in the configuration improves reproducibility and makes the resolved behavior easier to record with derivatives, while preserving the existing default.

## Behavior

The precedence order is:

1. `ica.ica_args.<run>.random_state`
2. top-level `random_seed`
3. historical fallback `97` for configurations created before this option existed

Example:

```yaml
random_seed: 97

ica:
  ica_args:
    run1:
      method: fastica
    run2:
      method: infomax
      random_state: 42
      fit_params:
        extended: true
```

Here, `run1` uses `97` and `run2` uses `42`.

Setting:

```yaml
random_seed: null
```

forwards `None` to ICA when no run-specific value is present, requesting non-deterministic initialization.

## Implementation

- Added `_get_ica_kwargs()` to centralize ICA parameter resolution.
- Added `random_seed: 97` to the adult, infant, and example configurations.
- Preserved the old implicit seed for legacy configuration files.
- Added validation for the global seed.
- Accepted NumPy integer scalars and normalized them to Python `int`.
- Kept run-specific `random_state` values unchanged and higher priority.
- Ensured parameter resolution does not mutate the user configuration.
- Added configuration and ICA documentation, including reproducibility limitations.

## Tests

Added 15 focused tests covering:

- adult and infant defaults;
- inheritance by both ICA runs;
- run-specific precedence;
- legacy configuration fallback;
- `None` behavior;
- invalid global values;
- NumPy integer normalization;
- non-mutation of the input configuration;
- YAML round-trip;
- invalid run names;
- end-to-end reproducibility with a real MNE ICA fit.

The end-to-end test fits ICA twice with the same global seed and verifies identical unmixing matrices.

Local results:

```text
15 passed  pylossless/tests/test_random_seed.py
8 passed   existing offline pipeline tests
3 passed   existing utils and simulated-data tests
ruff       passed
codespell  passed
git diff --check passed
```

## Backward compatibility

Existing configurations without `random_seed` continue to use `97`, matching the previous hard-coded behavior. Existing run-specific `random_state` settings continue to take precedence.

## Reproducibility limitation

A fixed seed controls pseudo-random initialization, but does not guarantee bitwise-identical results across different dependency versions, numerical backends, hardware, or thread configurations.

## Checklist

- [x] Tests added
- [x] Default configurations updated
- [x] Example configuration updated
- [x] Documentation added
- [x] Backward compatibility preserved
- [x] User configuration is not mutated during parameter resolution
